### PR TITLE
Add Allwinner H3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LD =  $(CROSS_COMPILE)ld
 OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
 REMOVE = rm -rf
-FEL ?= fel
+FEL ?= sunxi-fel
 
 # Compiler flags
 CFLAGS = -O2 -fno-common -fno-builtin -ffreestanding

--- a/README
+++ b/README
@@ -7,7 +7,7 @@ in that SoC.
 Usage
 =====
 The application is intended to be loaded into SRAM from the FEL mode with the
-'fel' tool available from https://github.com/linux-sunxi/sunxi-tools.
+'sunxi-fel' tool available from https://github.com/linux-sunxi/sunxi-tools.
 
 Embedded in the OpenRISC 1000 binary is a small ARM "boot loader",
 which is intended to be run first, it's sole purpose is to deassert the

--- a/README
+++ b/README
@@ -1,8 +1,8 @@
 Introduction
 ============
-A small OpenRISC 1000 baremetal application to be run on the Allwinner A31 SoC
-to gain some information about the AR100 core (an or1k implementation) present
-in that SoC.
+A small OpenRISC 1000 baremetal application to be run on the Allwinner A31
+and Allwinner H3 SoCs to gain some information about the AR100 core (an or1k
+implementation) present in that SoCs.
 
 Usage
 =====
@@ -46,7 +46,8 @@ i.e. all exception vectors have to be implemented like this:
 l.j exception_handler
  l.nop
 
-The actual contiguous SRAM memory starts at address 0x44000.
+The actual contiguous SRAM memory starts at address 0x44000. The size of this
+contiguous SRAM memory is 64 KiB in Allwinner A31 and 32 KiB in Allwinner H3.
 
 Results (application output)
 ============================

--- a/clock.h
+++ b/clock.h
@@ -53,6 +53,31 @@
 #define PLL6_CTRL_M(x)			(((x) & 0x3) << 0)
 #define PLL6_CTRL_M_MASK		(0x3 << 0)
 
+/* apb2 bit field */
+#define APB2_CLK_SRC_LOSC		(0x0 << 24)
+#define APB2_CLK_SRC_OSC24M		(0x1 << 24)
+#define APB2_CLK_SRC_PLL6		(0x2 << 24)
+#define APB2_CLK_SRC_MASK		(0x3 << 24)
+#define APB2_CLK_RATE_N_1		(0x0 << 16)
+#define APB2_CLK_RATE_N_2		(0x1 << 16)
+#define APB2_CLK_RATE_N_4		(0x2 << 16)
+#define APB2_CLK_RATE_N_8		(0x3 << 16)
+#define APB2_CLK_RATE_N_MASK		(3 << 16)
+#define APB2_CLK_RATE_M(m)		(((m)-1) << 0)
+#define APB2_CLK_RATE_M_MASK            (0x1f << 0)
+
+/* apb2 gate field */
+#define APB2_GATE_UART_SHIFT	(16)
+#define APB2_GATE_UART_MASK		(0xff << APB2_GATE_UART_SHIFT)
+#define APB2_GATE_TWI_SHIFT	(0)
+#define APB2_GATE_TWI_MASK		(0xf << APB2_GATE_TWI_SHIFT)
+
+/* apb2 reset */
+#define APB2_RESET_UART_SHIFT		(16)
+#define APB2_RESET_UART_MASK		(0xff << APB2_RESET_UART_SHIFT)
+#define APB2_RESET_TWI_SHIFT		(0)
+#define APB2_RESET_TWI_MASK		(0xf << APB2_RESET_TWI_SHIFT)
+
 /*
  * AR100 clock configuration register:
  * [31:18] Reserved

--- a/gpio.h
+++ b/gpio.h
@@ -161,6 +161,8 @@ enum sunxi_gpio_number {
 #define SUNXI_GPF4_SDC0_D3      (2)
 #define SUNXI_GPF4_UART0_RX     (4)
 
+#define SUN8I_H3_GPA_UART0	2
+
 int sunxi_gpio_set_cfgpin(u32 pin, u32 val);
 int sunxi_gpio_get_cfgpin(u32 pin);
 int sunxi_gpio_output(u32 pin, u32 val);

--- a/main.c
+++ b/main.c
@@ -110,6 +110,23 @@ static void put_uint(unsigned int value)
 	puts(p);
 }
 
+#define SRAM_VER_REG	(AW_SRAMCTRL_BASE + 0x24)
+
+void soc_detection_init(void)
+{
+	set_wbit(SRAM_VER_REG, 1 << 15);
+}
+
+int soc_is_a31(void)
+{
+	return (readl(SRAM_VER_REG) >> 16) == 0x1633;
+}
+
+int soc_is_h3(void)
+{
+	return (readl(SRAM_VER_REG) >> 16) == 0x1680;
+}
+
 void gpio_init()
 {
 	/* setup UART0 to PORTF */
@@ -376,6 +393,7 @@ int main(void)
 	unsigned int set_size;
 	unsigned int ways;
 
+	soc_detection_init();
 	gpio_init();
 	uart0_init();
 
@@ -529,11 +547,13 @@ int main(void)
 	puts("Test support for l.rori...");
 	test_rori() ? puts("yes\n") : puts("no\n");
 
-	puts("Init DRAM...");
-	mctl_init();
-	puts("done\n");
-	puts("Test DRAM read/write...");
-	test_dram();
+	if (soc_is_a31()) {
+		puts("Init DRAM...");
+		mctl_init();
+		puts("done\n");
+		puts("Test DRAM read/write...");
+		test_dram();
+	}
 
 	puts("Test timer functionality...");
 	test_timer();

--- a/main.c
+++ b/main.c
@@ -129,13 +129,18 @@ int soc_is_h3(void)
 
 void gpio_init()
 {
-	/* setup UART0 to PORTF */
-	/* disable GPH20,21 as uart0 tx,rx to avoid conflict */
-	gpio_direction_input(SUNXI_GPH(20));
-	gpio_direction_input(SUNXI_GPH(21));
-	/* Setup GPF2,4 as uart0 tx,rx */
-	sunxi_gpio_set_cfgpin(SUNXI_GPF(2), SUNXI_GPF2_UART0_TX);
-	sunxi_gpio_set_cfgpin(SUNXI_GPF(4), SUNXI_GPF4_UART0_RX);
+	if (soc_is_h3()) {
+		sunxi_gpio_set_cfgpin(SUNXI_GPA(4), SUN8I_H3_GPA_UART0);
+		sunxi_gpio_set_cfgpin(SUNXI_GPA(5), SUN8I_H3_GPA_UART0);
+	} else {
+		/* setup UART0 to PORTF */
+		/* disable GPH20,21 as uart0 tx,rx to avoid conflict */
+		gpio_direction_input(SUNXI_GPH(20));
+		gpio_direction_input(SUNXI_GPH(21));
+		/* Setup GPF2,4 as uart0 tx,rx */
+		sunxi_gpio_set_cfgpin(SUNXI_GPF(2), SUNXI_GPF2_UART0_TX);
+		sunxi_gpio_set_cfgpin(SUNXI_GPF(4), SUNXI_GPF4_UART0_RX);
+	}
 }
 
 /* Write a couple of words into the DRAM and read them back */

--- a/start.S
+++ b/start.S
@@ -47,7 +47,7 @@ ar100_boot:
 
 reset:
 	l.movhi	r0,0
-	l.ori	r1, r0, 0xfffc
+	l.ori	r1, r0, 0x7ffc
 	l.j	main
 	 l.nop
 

--- a/uart.c
+++ b/uart.c
@@ -74,6 +74,9 @@ void uart0_putc(char c)
 
 void uart0_puts(const char *s)
 {
-	while(*s)
+	while(*s) {
+		if (*s == '\n')
+			uart0_putc('\r');
 		uart0_putc(*s++);
+	}
 }

--- a/uart.c
+++ b/uart.c
@@ -26,9 +26,35 @@
 
 #include "io.h"
 #include "uart.h"
+#include "clock.h"
+
+#define CONFIG_CONS_INDEX 1
+
+#define APB2_DIV	(AW_CCM_BASE + 0x058)
+#define APB2_GATE	(AW_CCM_BASE + 0x06C)
+#define APB2_RESET	(AW_CCM_BASE + 0x2D8)
+
+void clock_init_uart(void)
+{
+	/* uart clock source is apb2 */
+	writel(APB2_CLK_SRC_OSC24M|
+	       APB2_CLK_RATE_N_1|
+	       APB2_CLK_RATE_M(1),
+	       APB2_GATE);
+
+	/* open the clock for uart */
+	set_wbit(APB2_GATE, 1 << (APB2_GATE_UART_SHIFT +
+				  CONFIG_CONS_INDEX - 1));
+
+	/* deassert uart reset */
+	set_wbit(APB2_RESET, 1 << (APB2_RESET_UART_SHIFT +
+				   CONFIG_CONS_INDEX - 1));
+}
 
 void uart0_init(void)
 {
+	clock_init_uart();
+
 	/* select dll dlh */
 	writel(0x80, UART0_LCR);
 	/* set baudrate */


### PR DESCRIPTION
Allwinner H3 is one of the new SoCs that is used in inexpensive development boards. Such as the Orange Pi PC, which costs only $15. These patches add support for Allwinner H3 to ar100-info.
