### PR TITLE
Bugfix for the stack location and benchmark for testing different types of memory

### DIFF
--- a/main.c
+++ b/main.c
@@ -228,7 +228,7 @@ void test_clk_freq(void)
 		put_uint(clk_freq);
 		puts(" KHz\n");
 	} else {
-		clk_freq = (clk_freq + 500) / 1e3;
+		clk_freq = (clk_freq + 500) / 1000;
 		put_uint(clk_freq);
 		puts(" MHz\n");
 	}

--- a/main.c
+++ b/main.c
@@ -699,10 +699,13 @@ int main(void)
 	puts("Test support for l.rori...");
 	test_rori() ? puts("yes\n") : puts("no\n");
 
-	if (soc_is_a31()) {
+	if (soc_is_a31() && !dram_is_clocked()) {
 		puts("Init DRAM...");
 		mctl_init();
 		puts("done\n");
+	}
+
+	if (dram_is_clocked()) {
 		puts("Test DRAM read/write...");
 		test_dram();
 	}

--- a/main.c
+++ b/main.c
@@ -140,6 +140,11 @@ int soc_is_h3(void)
 	return (readl(SRAM_VER_REG) >> 16) == 0x1680;
 }
 
+int dram_is_clocked(void)
+{
+    return readl(CCU_PLL5CFG) & (1 << 31);
+}
+
 void gpio_init()
 {
 	if (soc_is_h3()) {
@@ -353,6 +358,11 @@ void benchmark(void)
 			 &dummy);
 	test_mem_latency("   == Code in SRAM A2 (I-cache ON), data in SRAM A1 ==",
 			 (void *)0x40000);
+	if (dram_is_clocked()) {
+		test_mem_latency(
+			 "   == Code in SRAM A2 (I-cache ON), data in DRAM ==",
+			 (void *)0x40000000);
+	}
 
 	disable_caches();
 	puts("\n");
@@ -360,6 +370,11 @@ void benchmark(void)
 			 &dummy);
 	test_mem_latency("   == Code in SRAM A2 (I-cache OFF), data in SRAM A1 ==",
 			 (void *)0x40000);
+	if (dram_is_clocked()) {
+		test_mem_latency(
+			 "   == Code in SRAM A2 (I-cache OFF), data in DRAM ==",
+			 (void *)0x40000000);
+	}
 
 	puts("\n");
 }

--- a/start.S
+++ b/start.S
@@ -47,7 +47,7 @@ ar100_boot:
 
 reset:
 	l.movhi	r0,0
-	l.ori	r1, r0, 0x7ffc
+	l.ori	r1, r0, 0xbffc
 	l.j	main
 	 l.nop
 


### PR DESCRIPTION
Unfortunately my previous patch set had a problem in commit e5096906b42048a7f32259403f4fed3cfde14b2b because it effectively introduced 16K limit for the code+data+stack (instead of the intended 32K limit). And the ar100-info code is already slightly over 16K, which means that it worked in my tests only by pure miracle (the stack was small enough and did not manage to corrupt anything really important). The problem is now addressed in this patch set.

Also people may be curious about the SRAM and I-cache performance. This patch set introduces a simple benchmark for [SRAM A1, SRAM A2 and DRAM](https://linux-sunxi.org/AR100#Memory_Map), making the ar100-info output a bit more informative. DRAM can be initialized by U-Boot SPL and then used by ar100-info in the following way:

```
sunxi-fel -v spl sunxi-spl.bin && make load
```

The `sunxi-spl.bin` file is taken from the U-Boot build for the target hardware (`make CROSS_COMPILE=arm-linux-gnueabihf- orangepi_pc_defconfig`). Here is the example output from the [Orange Pi PC](http://linux-sunxi.org/Orange_Pi_PC) board (Allwinner H3):

<pre>
OpenRISC-1200 (rev 1)
D-Cache: no
I-Cache: 4096 bytes, 16 bytes/line, 1 way(s)
DMMU: no
IMMU: no
MAC unit: yes
Debug unit: yes
Performance counters: no
Power management: yes
Interrupt controller: yes
Timer: yes
Custom unit(s): no
ORBIS32: yes
ORBIS64: no
ORFPX32: no
ORFPX64: no
Test support for l.addc...yes
Test support for l.cmov...yes
Test support for l.cust1...no
Test support for l.cust2...no
Test support for l.cust3...no
Test support for l.cust4...no
Test support for l.cust5...no
Test support for l.cust6...no
Test support for l.cust7...no
Test support for l.cust8...no
Test support for l.div...yes
Test support for l.divu...yes
Test support for l.extbs...yes
Test support for l.extbz...yes
Test support for l.exths...yes
Test support for l.exthz...yes
Test support for l.extws...yes
Test support for l.extwz...yes
Test support for l.ff1...yes
Test support for l.fl1...yes
Test support for l.lws...no
Test support for l.mac...yes
Test support for l.maci...yes
Test support for l.macrc...yes
Test support for l.mul...yes
Test support for l.muli...yes
Test support for l.mulu...yes
Test support for l.ror...yes
Test support for l.rori...yes
Test DRAM read/write...OK
Test timer functionality...OK
Set clock source to LOSC...done
Test CLK freq...33 KHz
Set clock source to HOSC (POSTDIV=0, DIV=0)...done
Test CLK freq...24 MHz
Set clock source to HOSC (POSTDIV=0, DIV=1)...done
Test CLK freq...12 MHz
Set clock source to HOSC (POSTDIV=1, DIV=1)...done
Test CLK freq...12 MHz
Setup PLL6 (M=1, K=1, N=24)...done
Set clock source to PLL6 (POSTDIV=1, DIV=0)...done
Test CLK freq...300 MHz

  == Benchmark ==
   == Code in SRAM A2 (I-cache ON), data in SRAM A2 ==
      Instructions fetch : 1.0 cycles per instruction
      Back-to-back L.LWZ : 3.0 cycles per 32-bit read
           L.LWZ + L.NOP : 4.0 cycles per 32-bit read
   == Code in SRAM A2 (I-cache ON), data in SRAM A1 ==
      Instructions fetch : 1.0 cycles per instruction
      Back-to-back L.LWZ : 25.7 cycles per 32-bit read
           L.LWZ + L.NOP : 27.7 cycles per 32-bit read
   == Code in SRAM A2 (I-cache ON), data in DRAM ==
      Instructions fetch : 1.0 cycles per instruction
      Back-to-back L.LWZ : 60.8 cycles per 32-bit read
           L.LWZ + L.NOP : 62.4 cycles per 32-bit read

   == Code in SRAM A2 (I-cache OFF), data in SRAM A2 ==
      Instructions fetch : 3.0 cycles per instruction
      Back-to-back L.LWZ : 4.5 cycles per 32-bit read
           L.LWZ + L.NOP : 8.0 cycles per 32-bit read
   == Code in SRAM A2 (I-cache OFF), data in SRAM A1 ==
      Instructions fetch : 3.0 cycles per instruction
      Back-to-back L.LWZ : 31.7 cycles per 32-bit read
           L.LWZ + L.NOP : 34.6 cycles per 32-bit read
   == Code in SRAM A2 (I-cache OFF), data in DRAM ==
      Instructions fetch : 3.0 cycles per instruction
      Back-to-back L.LWZ : 64.0 cycles per 32-bit read
           L.LWZ + L.NOP : 67.8 cycles per 32-bit read

Set clock source to PLL6 (POSTDIV=2, DIV=0)...done
Test CLK freq...200 MHz
Set clock source to PLL6 (POSTDIV=2, DIV=1)...done
Test CLK freq...100 MHz
Setup PLL6 (M=2, K=1, N=24)...done
Test CLK freq...100 MHz
Setup PLL6 (M=1, K=2, N=24)...done
Test CLK freq...150 MHz
Setup PLL6 (M=1, K=1, N=12)...done
Test CLK freq...52 MHz
Restore clock config to original state...done
All tests completed!
</pre>

If the DRAM is not initialized (when running ar100-info directly), then the DRAM benchmark gets automatically skipped and is not present in the log.

Additionally, ar100-info now works on Allwinner A31s hardware if DRAM is initialized by U-Boot SPL in the same way as on Allwinner H3.
